### PR TITLE
Rename "zerocashd" to "zcash" everywhere and nuke a giant comment blo…

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -110,39 +110,13 @@ WEB_CREDS = load_webcreds(eu('~/webcreds.json'))
 
 
 BuildmasterConfig = {
-    'title': "zerocashd",
-    'titleURL': "https://github.com/Electric-Coin-Company/zerocashd",
+    'title': "zcash",
+    'titleURL': "https://github.com/Electric-Coin-Company/zcash",
     'buildbotURL': "http://ci.leastauthority.com:8010/",
     'db': { 'db_url' : "sqlite:///state.sqlite" },
     'protocols': {'pb': {'port': 9899}},
 
-    # We use the 'project' attribute to tag changes with either libzerocash
-    # or zerocashd, depending on which repository they came from. We have
-    # to do this because Buildbot's default mode is to pass all changes
-    # to all schedulers, which means zerocashd changes will cause
-    # the libzerocash builder to run. 
-    #
-    # Changes from the GitHub WebStatus change hook come in with the project
-    # attribute already set, which is of the form...
-    #   Electric-Coin-Company/libzerocash
-    # ...so we make these pollers use exactly the same syntax.
-    'change_source': [
-        ## Disabled the pollers since the webhook is sufficient.
-        # changes.GitPoller(
-        #     'https://github.com/Electric-Coin-Company/libzerocash',
-        #     workdir='libzc-gitpoller-workdir',
-        #     branches=True,
-        #     pollinterval=300,
-        #     project='Electric-Coin-Company/libzerocash',
-        # ),
-        # changes.GitPoller(
-        #     'git@github.com:Electric-Coin-Company/zerocashd',
-        #     workdir='zc-gitpoller-workdir',
-        #     branches=True,
-        #     pollinterval=300,
-        #     project='Electric-Coin-Company/zerocashd',
-        # ),
-    ],
+    'change_source': [],
 
     # Here's where we use the 'project' attribute to decide which
     # builder the change event should trigger.
@@ -156,27 +130,27 @@ BuildmasterConfig = {
             builderNames=["libzerocash"],
         ),
         schedulers.AnyBranchScheduler(
-            name="zerocashd-any-branch-45s",
+            name="zcash-any-branch-45s",
             treeStableTimer=45,
             change_filter=ChangeFilter(
-                project="Electric-Coin-Company/zerocashd",
+                project="Electric-Coin-Company/zcash",
             ),
-            builderNames=["zerocashd"],
+            builderNames=["zcash"],
         ),
         # FIXME: Do we have to fix the force scheduler in the same way?
         schedulers.ForceScheduler(
             name="force",
-            builderNames=["libzerocash", "zerocashd"],
+            builderNames=["libzerocash", "zcash"],
         ),
     ],
 
     'builders': [
         util.BuilderConfig(
-            name="zerocashd",
+            name="zcash",
             slavenames=[SLAVE_NAME],
             factory=util.BuildFactory([
                 steps.Git(
-                    repourl='git@github.com:Electric-Coin-Company/zerocashd',
+                    repourl='git@github.com:Electric-Coin-Company/zcash',
                     mode='incremental',
                 ),
                 sh('git', 'clean', '-dfx', name='git clean'),
@@ -190,7 +164,7 @@ BuildmasterConfig = {
             ]),
             properties={
                 "github_repo_owner": "Electric-Coin-Company",
-                "github_repo_name": "zerocashd",
+                "github_repo_name": "zcash",
             },
         ),
         util.BuilderConfig(


### PR DESCRIPTION
…ck. (Untested commit due to poor deployment restrictions.)

Note: This loses all history for "zerocashd" builds in the UI.  Is this a blocker?  I'll assume no unless I hear otherwise from anyone.